### PR TITLE
fix: Convert float device_info values to integers to prevent TypeErro…

### DIFF
--- a/SCR/valetudo_map_parser/__init__.py
+++ b/SCR/valetudo_map_parser/__init__.py
@@ -1,5 +1,5 @@
 """Valetudo map parser.
-Version: 0.2.2"""
+Version: 0.2.3"""
 
 from pathlib import Path
 

--- a/SCR/valetudo_map_parser/config/shared.py
+++ b/SCR/valetudo_map_parser/config/shared.py
@@ -287,17 +287,17 @@ class CameraSharedManager:
             instance.attr_calibration_points = None
 
             # Initialize shared data with defaults from DEFAULT_VALUES
-            instance.offset_top = device_info.get(
-                CONF_OFFSET_TOP, DEFAULT_VALUES["offset_top"]
+            instance.offset_top = int(
+                device_info.get(CONF_OFFSET_TOP, DEFAULT_VALUES["offset_top"])
             )
-            instance.offset_down = device_info.get(
-                CONF_OFFSET_BOTTOM, DEFAULT_VALUES["offset_bottom"]
+            instance.offset_down = int(
+                device_info.get(CONF_OFFSET_BOTTOM, DEFAULT_VALUES["offset_bottom"])
             )
-            instance.offset_left = device_info.get(
-                CONF_OFFSET_LEFT, DEFAULT_VALUES["offset_left"]
+            instance.offset_left = int(
+                device_info.get(CONF_OFFSET_LEFT, DEFAULT_VALUES["offset_left"])
             )
-            instance.offset_right = device_info.get(
-                CONF_OFFSET_RIGHT, DEFAULT_VALUES["offset_right"]
+            instance.offset_right = int(
+                device_info.get(CONF_OFFSET_RIGHT, DEFAULT_VALUES["offset_right"])
             )
             instance.image_auto_zoom = device_info.get(
                 CONF_AUTO_ZOOM, DEFAULT_VALUES["auto_zoom"]
@@ -320,8 +320,8 @@ class CameraSharedManager:
             instance.vacuum_status_font = device_info.get(
                 CONF_VAC_STAT_FONT, DEFAULT_VALUES["vac_status_font"]
             )
-            instance.vacuum_status_size = device_info.get(
-                CONF_VAC_STAT_SIZE, DEFAULT_VALUES["vac_status_size"]
+            instance.vacuum_status_size = int(
+                device_info.get(CONF_VAC_STAT_SIZE, DEFAULT_VALUES["vac_status_size"])
             )
             instance.vacuum_status_position = device_info.get(
                 CONF_VAC_STAT_POS, DEFAULT_VALUES["vac_status_position"]
@@ -338,7 +338,12 @@ class CameraSharedManager:
             elif robot_size > 25:
                 robot_size = 25
             instance.robot_size = robot_size
-            instance.mop_path_width = device_info.get("mop_path_width", robot_size - 2)
+            # Mop path width - ensure it's an integer
+            mop_path_width = device_info.get("mop_path_width", robot_size - 2)
+            try:
+                instance.mop_path_width = int(mop_path_width)
+            except (ValueError, TypeError):
+                instance.mop_path_width = robot_size - 2
 
             # Check for new floors_data first
             floors_data = device_info.get("floors_data", {})

--- a/SCR/valetudo_map_parser/config/types.py
+++ b/SCR/valetudo_map_parser/config/types.py
@@ -85,10 +85,10 @@ class TrimCropData:
         """Create dataclass from dictionary."""
         return TrimCropData(
             floor=data.get("floor", "floor_0"),
-            trim_left=data["trim_left"],
-            trim_up=data["trim_up"],
-            trim_right=data["trim_right"],
-            trim_down=data["trim_down"],
+            trim_left=int(data["trim_left"]),
+            trim_up=int(data["trim_up"]),
+            trim_right=int(data["trim_right"]),
+            trim_down=int(data["trim_down"]),
         )
 
     def to_list(self) -> list:
@@ -100,10 +100,10 @@ class TrimCropData:
         """Create dataclass from list [trim_left, trim_up, trim_right, trim_down]."""
         return TrimCropData(
             floor=floor,
-            trim_left=data[0],
-            trim_up=data[1],
-            trim_right=data[2],
-            trim_down=data[3],
+            trim_left=int(data[0]),
+            trim_up=int(data[1]),
+            trim_right=int(data[2]),
+            trim_down=int(data[3]),
         )
 
 
@@ -305,10 +305,10 @@ class TrimsData:
         data = json.loads(json_data)
         return cls(
             floor=data.get("floor", ""),
-            trim_up=data.get("trim_up", 0),
-            trim_left=data.get("trim_left", 0),
-            trim_down=data.get("trim_down", 0),
-            trim_right=data.get("trim_right", 0),
+            trim_up=int(data.get("trim_up", 0)),
+            trim_left=int(data.get("trim_left", 0)),
+            trim_down=int(data.get("trim_down", 0)),
+            trim_right=int(data.get("trim_right", 0)),
         )
 
     def to_json(self) -> str:
@@ -318,7 +318,13 @@ class TrimsData:
     @classmethod
     def from_dict(cls, data: dict):
         """Initialize TrimData from a dictionary."""
-        return cls(**data)
+        return cls(
+            floor=data.get("floor", ""),
+            trim_up=int(data.get("trim_up", 0)),
+            trim_left=int(data.get("trim_left", 0)),
+            trim_down=int(data.get("trim_down", 0)),
+            trim_right=int(data.get("trim_right", 0)),
+        )
 
     def to_dict(self) -> dict:
         """Convert TrimData to a dictionary."""
@@ -333,10 +339,10 @@ class TrimsData:
         assigns crop_area[0] to trim_up and crop_area[1] to trim_left which seems reversed.
         """
         return cls(
-            trim_up=crop_area[0],
-            trim_left=crop_area[1],
-            trim_down=crop_area[2],
-            trim_right=crop_area[3],
+            trim_up=int(crop_area[0]),
+            trim_left=int(crop_area[1]),
+            trim_down=int(crop_area[2]),
+            trim_right=int(crop_area[3]),
             floor=floor,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "valetudo-map-parser"
-version = "0.2.2"
+version = "0.2.3"
 description = "A Python library to parse Valetudo map data returning a PIL Image object."
 authors = ["Sandro Cantarella <gsca075@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
…r on Pi4 (#45)

* adding const.py and update types.py to separate const and types



* last files for 12 isort / ruff and lint



* remove duplicate import of const



* const was not properly imported



* minor changes in rand256_handler.py, shared.py removed snapshot at init bump version in pyproject.toml added to __init__.py Trims and Floor Data



* updated __init__.py



* updated __init__.py all



* updated __init__.py all



* update shared.py to load floor data from the config if present else uses old key trims_data



* update TrimsCropData to use the floors when init, else default values.



* feat: Add carpet zone detection and rendering support

- Add CARPET drawable element with configurable color and alpha
- Implement carpet zone parsing from Valetudo JSON (PolygonMapEntity)
- Add carpet rendering with customizable color (default: 50% of room_0)
- Support disable_carpets flag to toggle carpet visibility
- Fix COLORS list order to match base_color_keys mapping
- Fix floor rendering to use correct MAP_BACKGROUND color
- Add carpet color configuration to device_info

Fixes color index mismatch that affected carpet and floor color updates



* feat: Add carpet zone detection and rendering support from_list



* fix: Add missing CARPET to element_color_mapping

Fixes carpet color/alpha from device_info not being applied due to missing DrawableElement.CARPET entry in update_from_device_info().



* Dead code removed. The _draw_carpets method was leftover from the initial implementation attempt and is not needed since we're using the simpler approach of passing color_carpet directly from device_info to the zones() drawing method.



* Materials implementation and configuration



* removed test and unused code _update_material_colors()



* improved material.py drawings with mcvrender



* isort and ruffed code and added configurable colours for material.py



* updated types.py isort and ruff



* updated drawable_elements.py with correct colors name for material



* double import correction in colors.py and indexing



* use MaterialColor instead of direct access.



* feat: Add mop mode path width adjustment for Hypfer vacuums

- Path width adjusts to robot_size - 2 when mop_mode=True (default: 5px)
- Cache robot_size in ImageDraw for performance
- Update handler to use cached robot_size
- Test with mop_mode enabled in test.py

When mop mode is active, path width visually represents mop coverage area.



* refactor: remove unused apply_overlay_on_region method from MaterialTileRenderer

Remove dead code from MaterialTileRenderer class in material.py:
- Deleted apply_overlay_on_region() static method (lines 210-223)
- Method was never called anywhere in the codebase
- Duplicated functionality already implemented in hypfer_draw._apply_material_overlay()
- Removed implementation used inferior mask-based assignment vs proper alpha blending

The active material overlay implementation in hypfer_draw.py continues to use:
- MaterialTileRenderer.get_tile() for tile generation
- MaterialTileRenderer.tile_block() for tile positioning
- Proper alpha blending: region[:] = (1 - alpha) * region + alpha * overlay

This cleanup eliminates 15 lines of unused code while maintaining all functional material overlay capabilities.



* refactor: Replace hardcoded color indices with named ColorIndex enum

Replace all hardcoded user_colors[x] array indices with a ColorIndex IntEnum to prevent breakage when color order changes and improve code maintainability.

Changes:
- Add ColorIndex IntEnum in config/colors.py with named constants for all user_colors array indices (WALL=0, ZONE_CLEAN=1, ROBOT=2, BACKGROUND=3, MOVE=4, CHARGER=5, CARPET=6, NO_GO=7, GO_TO=8, TEXT=9, MATERIAL_WOOD=10, MATERIAL_TILE=11)
- Add 'material_wood' and 'material_tile' to COLORS list in const.py to match the actual colors being initialized
- Replace user_colors[10] and user_colors[11] with ColorIndex.MATERIAL_WOOD and ColorIndex.MATERIAL_TILE in hypfer_draw.py
- Replace user_colors[8] with ColorIndex.TEXT in config/utils.py

Benefits:
- Self-documenting code with named constants instead of magic numbers
- Type-safe access to color indices
- Easy to maintain and reorder colors without breaking existing code
- Clear mapping between color names and their array positions

Tested: Hypfer test passes successfully with all colors initialized correctly


* Release v0.2.0 - Major Color System Refactoring and Code Quality Improvements

## Version Update
- Bumped version to 0.2.0 across pyproject.toml, __init__.py, and README.md

## Color System Enhancements

### ColorIndex Enum Implementation
- Created ColorIndex IntEnum with named constants for all user_colors array indices
- Replaced hardcoded numeric indices (user_colors[8], [10], [11]) with type-safe enum constants
- Prevents breakage when color order changes in the future
- Updated hypfer_draw.py to use ColorIndex.MATERIAL_WOOD and ColorIndex.MATERIAL_TILE
- Updated utils.py to use ColorIndex.TEXT for status text rendering

### Material Colors Refactoring
- Refactored MaterialTileRenderer to use MaterialColors dataclass
- Made material overlay colors (wood and tile) user-configurable via device_info
- Removed hardcoded class variables WOOD_RGBA/TILE_RGBA and set_colors()/reset_colors() methods
- All rendering methods now accept color parameters instead of using class state
- Added material color constants to DEFAULT_VALUES (color_material_wood, color_material_tile)
- Updated material overlay implementation to extract colors from shared.user_colors

### Color Initialization Fix
- Fixed initialize_user_colors() to use same base_color_keys order as set_initial_colours() and ColorIndex enum
- Prevents color index mismatches during initialization
- Added 'material_wood' and 'material_tile' to COLORS list in const.py

### Color Blending Implementation
- Implemented color blending for semi-transparent elements using mvcrender's sample_and_blend_color
- Applied blending to flag, obstacles, and charger elements when alpha < 255
- Optimized alpha blending to minimize temporary allocations in zone drawing

### Path Color Enhancements
- Updated default path color to more vibrant blue (50, 150, 255) for better visibility
- Implemented mop mode path width adjustment: path_width = max(1, robot_size - 2) when mop_mode=True
- Added robot_size caching in ImageDraw to reduce shared data access
- Path lines now support different colors when crossing different rooms

### Alpha Transparency Updates
- Updated default alpha values: path (200.0), walls (150.0)
- Semi-transparent elements (restricted areas, no-mop areas, predicted path) default to alpha=125.0

## Code Quality Improvements

### Logging Cleanup
- Converted 24+ INFO logs to DEBUG level across 5 files to reduce production log noise
  - hypfer_handler.py: 5 logs converted
  - rand256_handler.py: 4 logs converted
  - hypfer_draw.py: 1 log converted + fixed misleading else clause
  - reimg_draw.py: 8 logs converted + fixed else clause pattern
  - drawable_elements.py: 6 logs converted + removed duplicate logging
- Fixed misleading else-clause logging patterns in virtual walls and entity dict methods
- Removed duplicate log statements in enable_element/disable_element methods

### Dead Code Removal
- Removed unused material_mvcrender.py (test/alternative implementation)
- Removed unused apply_overlay_on_region() static method from MaterialTileRenderer

## Documentation Updates
- Updated Python requirement documentation from 3.12 to 3.13 in README.md
- Added complete dependency list with version constraints:
  - Pillow (>=10.3.0)
  - NumPy (>=1.26.4)
  - SciPy (>=1.12.0)
  - mvcrender (==0.0.7)

## Performance Optimizations
- Added mop_mode attribute to CameraShared class for tracking vacuum operation mode
- Cached robot_size in ImageDraw to avoid repeated shared data access
- Optimized color blending operations to reduce memory allocations

## Deferred Issues (Medium Priority)
- Pylint disabled in CI since refactoring (to be re-enabled)
- Potential null reference in _convert_to_binary when last_image is None
- Room ID indexing inconsistency (0-based vs 1-based)
- Potential race conditions in async shared data access
- Hardcoded /tmp/ paths in tests (Windows incompatible)
- Virtual walls logging pattern needs review



* chore: bump version to 0.2.1 with mvcrender 0.0.8 dependency update

- Updated mvcrender dependency from 0.0.7 to 0.0.8 (critical trim swap fix)
- Updated TrimsData.from_list() docstring to reflect actual implementation
- Added investigation note for future parameter mapping review

This patch release addresses critical autocrop trim coordinate handling with the updated mvcrender dependency.



* feat: Add mop path customization for Hypfer vacuums (v0.2.2)

Add three new configuration options for customizing mop path rendering when vacuum is in mop mode (Hypfer vacuums only):

- mop_path_width: Configurable path width (default: robot_size - 2)
- color_mop_move: RGB color for mop path (default: [238, 247, 255])
- alpha_mop_move: Alpha transparency (default: 100.0)

Changes:
- const.py: Added COLOR_MOP_MOVE and ALPHA_MOP_MOVE constants with defaults
- colors.py: Integrated mop_move into color system (ColorIndex.MOP_MOVE = 12)
- shared.py: Added mop_path_width property to CameraShared class
- hypfer_draw.py: Updated async_draw_paths() to use mop settings when mop_mode=True
- test.py: Added mop path configuration to test device_info

Features:
- Fully backward compatible (all options optional with sensible defaults)
- Auto-detection of mop mode from JSON data
- Hypfer-only implementation (Rand256 vacuums don't support mop mode)

Version: 0.2.2
Python requirement: >=3.12 (Home Assistant compatibility)



* formatting



* chore: Bump version to 0.2.3

fix: Convert float device_info values to integers to prevent TypeError on Pi4

On Raspberry Pi 4 and other systems, Home Assistant can pass device_info configuration values as floats (e.g., 255.0, 100.0) even when they should be integers. This caused "TypeError: 'float' object cannot be interpreted as an integer" when AutoCrop initialization accessed these values.

Changes:
- Convert offset values (offset_top, offset_down, offset_left, offset_right) to int
- Convert size values (vacuum_status_size, mop_path_width) to int with error handling
- Update TrimsData.from_dict(), from_json(), and from_list() to convert trim values to int
- Update TrimCropData.from_dict() and from_list() to convert trim values to int
- Fix typo in tests/test.py: trim_left 240.0 → 2400.0
- Bump version from 0.2.2 to 0.2.3 in pyproject.toml and __init__.py

Note: Color alpha values intentionally remain as floats in device_info and are converted to integers only when creating final RGBA tuples, so color handling is unaffected.

Fixes compatibility issue on Raspberry Pi 4 and ensures all numeric values that should be integers are properly converted regardless of input type.



---------